### PR TITLE
Remove duplicate player load handler in respawn_alignment

### DIFF
--- a/respawn/server-data-es/resources/[respawn]/respawn_alignment/server.lua
+++ b/respawn/server-data-es/resources/[respawn]/respawn_alignment/server.lua
@@ -80,7 +80,6 @@ local function savePlayer(src)
     {d.heat, d.civis, d.active, d.lastSwitch, d.citizenid})
 end
 
-AddEventHandler('QBCore:Server:PlayerLoaded', function(src) loadPlayer(src) end)
 AddEventHandler('playerDropped', function() savePlayer(source); P[source]=nil end)
 AddEventHandler('QBCore:Server:PlayerLoaded', function(src)
   loadPlayer(src)


### PR DESCRIPTION
## Summary
- ensure only one QBCore PlayerLoaded handler is registered in respawn_alignment

## Testing
- `lua -v`
- `luac -p respawn/server-data-es/resources/[respawn]/respawn_alignment/server.lua`


------
https://chatgpt.com/codex/tasks/task_e_689fa619fc3483289cfe2b222c5226b2