### PR TITLE
Remove duplicate player load handler in respawn_alignment

### DIFF
--- a/respawn/server-data-es/resources/[respawn]/respawn_alignment/server.lua
+++ b/respawn/server-data-es/resources/[respawn]/respawn_alignment/server.lua
@@ -80,7 +80,6 @@ local function savePlayer(src)
     {d.heat, d.civis, d.active, d.lastSwitch, d.citizenid})
 end
 
-AddEventHandler('QBCore:Server:PlayerLoaded', function(src) loadPlayer(src) end)
 AddEventHandler('playerDropped', function() savePlayer(source); P[source]=nil end)
 AddEventHandler('QBCore:Server:PlayerLoaded', function(src)
   loadPlayer(src)

--- a/respawn/server-data-es/resources/[respawn]/respawn_weapons/server.lua
+++ b/respawn/server-data-es/resources/[respawn]/respawn_weapons/server.lua
@@ -1,12 +1,23 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 local ox = exports.oxmysql
+local Catalog = {}
 
--- Carga catálogo
-local catalogJson = LoadResourceFile(GetCurrentResourceName(), 'data/weapons_catalog.json')
-local Catalog = json.decode(catalogJson or '{}')
--- EXPORTS para otros recursos
+local function loadCatalog()
+  local raw = LoadResourceFile(GetCurrentResourceName(), 'data/weapons_catalog.json')
+  assert(raw, '^1[respawn_weapons]^7 weapons_catalog.json no encontrado')
+  local ok, decoded = pcall(json.decode, raw)
+  assert(ok and decoded, '^1[respawn_weapons]^7 JSON inválido en weapons_catalog.json')
+  Catalog = decoded
+end
+
+loadCatalog()
+
 exports('GetCatalogFamilies', function()
   return Catalog and Catalog.families or {}
+end)
+
+exports('GetProgressionChain', function()
+  return Progression
 end)
 
 
@@ -82,27 +93,7 @@ RegisterNetEvent('respawn:weapons:claim', function(family, branch, level)
     local wait = (info and info.wait) or 0
     TriggerClientEvent('QBCore:Notify', src, ('Encargo iniciado: listo en %ds'):format(wait), 'primary')
   end
-end)
-
-local Catalog = {}
-
-local function loadCatalog()
-  local raw = LoadResourceFile(GetCurrentResourceName(), 'data/weapons_catalog.json')
-  assert(raw, '^1[respawn_weapons]^7 weapons_catalog.json no encontrado')
-  local ok, decoded = pcall(json.decode, raw)
-  assert(ok and decoded, '^1[respawn_weapons]^7 JSON inválido en weapons_catalog.json')
-  Catalog = decoded
-end
-
-CreateThread(loadCatalog)
-
-exports('GetCatalogFamilies', function()
-  return Catalog and Catalog.families or {}
-end)
-
-exports('GetProgressionChain', function()
-  return Progression
-end)
+  end)
 
 
 -- ====== Grant interno (llamado por workshops al completar) ======

--- a/respawn/server-data-es/resources/[respawn]/respawn_workshops/server.lua
+++ b/respawn/server-data-es/resources/[respawn]/respawn_workshops/server.lua
@@ -187,7 +187,7 @@ exports('RequestClaim', function(src, family, branch, level)
   if costCash > 0 then Player.Functions.RemoveMoney('cash', costCash, 'respawn-claim') end
   removeMaterials(src, mats)
 
-  local ready = now() + (prev.timeSec or 0)
+  local ready = os.time() + (prev.timeSec or 0)
   local id = ox:executeSync(
     'INSERT INTO respawn_work_orders (citizenid,family,branch,level,ready_at) VALUES (?,?,?,?,?)',
     {cid, family, branch, level, ready}


### PR DESCRIPTION
## Summary
- ensure only one QBCore PlayerLoaded handler is registered in respawn_alignment
- load weapons catalog once and export progression chain
- fix workshop order timers using os.time

## Testing
- `lua -v`
- `luac -p respawn/server-data-es/resources/[respawn]/respawn_weapons/server.lua`
- `luac -p respawn/server-data-es/resources/[respawn]/respawn_workshops/server.lua`


------
https://chatgpt.com/codex/tasks/task_e_689fa619fc3483289cfe2b222c5226b2