### PR TITLE
Fix workshop scripts for Respawn server

### DIFF
--- a/respawn/server-data-es/resources/[respawn]/respawn_workshops/client.lua
+++ b/respawn/server-data-es/resources/[respawn]/respawn_workshops/client.lua
@@ -29,8 +29,11 @@ local function openQuickMenu(branch)
   while not cbReady do Wait(0) end
 
   if (not options) or #options == 0 then
-    lib and lib.notify({title='Respawn', description='Nada disponible para reclamar en esta rama.', type='error'}) or
-    print('[Respawn] Nada disponible para reclamar.')
+    if hasLib and lib and lib.notify then
+      lib.notify({title='Respawn', description='Nada disponible para reclamar en esta rama.', type='error'})
+    else
+      print('[Respawn] Nada disponible para reclamar.')
+    end
     return
   end
 
@@ -62,7 +65,7 @@ local function openQuickMenu(branch)
 end
 
 local function spawnWorkshopNPC(branch, data)
-  local m = loadModel(data.pedModel or `s_m_m_autoshop_02`)
+  local m = loadModel(data.pedModel or 's_m_m_autoshop_02')
   local ped = CreatePed(4, m, data.coords.x, data.coords.y, data.coords.z-1.0, data.heading or 0.0, false, true)
   SetEntityAsMissionEntity(ped, true, true)
   SetBlockingOfNonTemporaryEvents(ped, true)

--- a/respawn/server-data-es/resources/[respawn]/respawn_workshops/config.lua
+++ b/respawn/server-data-es/resources/[respawn]/respawn_workshops/config.lua
@@ -3,14 +3,14 @@ Workshops = {
     label = 'Taller Corporativo',
     coords = vec3(-339.60, -136.75, 39.00),
     heading = 70.0,
-    pedModel = `s_m_m_autoshop_02`,   -- modelo ped sugerido
+    pedModel = 's_m_m_autoshop_02',   -- modelo ped sugerido
     scenario = 'WORLD_HUMAN_CLIPBOARD'
   },
   heat = {
     label = 'Taller Clandestino',
     coords = vec3(1173.35, -1325.70, 35.20),
     heading = 180.0,
-    pedModel = `g_m_m_cartelguards_01`,
+    pedModel = 'g_m_m_cartelguards_01',
     scenario = 'WORLD_HUMAN_HAMMERING'
   }
 }


### PR DESCRIPTION
## Summary
- replace FiveM backtick model hashes in workshop config with plain strings
- handle missing options in workshop client with explicit notify fallback
- use string default when spawning workshop NPCs

## Testing
- `find respawn/server-data-es/resources/[respawn] -name '*.lua' -print0 | xargs -0 -n 1 luac -p`

------
https://chatgpt.com/codex/tasks/task_e_689fbc26963c832893b7545a1d529c7d