### PR TITLE
Fix order of score mapping in respawn alignment

### DIFF
--- a/respawn/server-data/resources/[respawn]/respawn_alignment/server.lua
+++ b/respawn/server-data/resources/[respawn]/respawn_alignment/server.lua
@@ -22,6 +22,14 @@ end)
 
 local function clamp(v, a, b) return math.max(a, math.min(b, v)) end
 
+-- map score (0..100) to eligible level using config table
+local function levelFromScore(score)
+  for _,m in ipairs(AlignmentConfig.ScoreToLevel) do
+    if score>=m.min and score<=m.max then return m.lvl end
+  end
+  return 0
+end
+
 local function sendClientState(src)
   local d = P[src]; if not d then return end
   local st = {
@@ -34,14 +42,6 @@ local function sendClientState(src)
     }
   }
   TriggerClientEvent('respawn:alignment:clientState', src, st)
-end
-
-
-local function levelFromScore(score)
-  for _,m in ipairs(AlignmentConfig.ScoreToLevel) do
-    if score>=m.min and score<=m.max then return m.lvl end
-  end
-  return 0
 end
 
 local function computeBranch(heat, civis, prevActive)


### PR DESCRIPTION
## Summary
- ensure `levelFromScore` is defined before use in respawn_alignment server

## Testing
- `luac -p respawn/server-data/resources/[respawn]/respawn_alignment/server.lua`
- `for f in $(find respawn/server-data/resources/'[respawn]' -name '*.lua'); do luac -p "$f" && echo "OK $f"; done`

------
https://chatgpt.com/codex/tasks/task_e_68a085f602c08328b7c2a6ff043346e8