### PR TITLE
fix: avoid double weapon equip client event

### DIFF
--- a/respawn/server-data/resources/[respawn]/respawn_weapons/client.lua
+++ b/respawn/server-data/resources/[respawn]/respawn_weapons/client.lua
@@ -1,15 +1,12 @@
 -- Cliente no toca DB; sólo existe para utilidades o aplicar efectos en el futuro.
 -- Aquí podrías escuchar un evento 'equip-changed' para aplicar adjuntos/skins.
 
-RegisterNetEvent('respawn:weapons:equipped', function(family, level)
-  print(('[Respawn] Equipped %s +%d'):format(family, level))
-end)
 -- Escucha cuando equipes (ya existe el evento). Aplica pequeño efecto de cámara opcional:
 RegisterNetEvent('respawn:weapons:equipped', function(family, level)
+  print(('[Respawn] Equipped %s +%d'):format(family, level))
   -- TODO: una integración real con natives de armas por jugador
   -- Ejemplo suave (no invasivo): pequeño feedback al equipar high tier
   if level >= 7 then
     ShakeGameplayCam('SMALL_EXPLOSION_SHAKE', 0.15)
   end
 end)
-


### PR DESCRIPTION
## Summary
- merge duplicate `respawn:weapons:equipped` client events into one handler
- only shake the gameplay camera for high-tier levels (>=7)

## Testing
- `luac -p respawn/server-data/resources/[respawn]/respawn_weapons/client.lua`
- `luacheck respawn/server-data/resources/[respawn]/respawn_weapons/client.lua` *(fails: command not found, package unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a09123459c8328959e613534cfa8c4