### PR TITLE
Add indexes for respawn work orders and keep resumePendingOrders

### DIFF
--- a/respawn/server-data/resources/[respawn]/respawn_workshops/server.lua
+++ b/respawn/server-data/resources/[respawn]/respawn_workshops/server.lua
@@ -24,7 +24,7 @@ local function humanError(code)
 end
 
 local function ensureSchema()
-  ox:executeSync([[
+  ox:executeSync([[ 
     CREATE TABLE IF NOT EXISTS respawn_work_orders (
       id INT NOT NULL AUTO_INCREMENT,
       citizenid VARCHAR(46) NOT NULL,
@@ -33,7 +33,10 @@ local function ensureSchema()
       level INT NOT NULL,
       ready_at INT NOT NULL,
       status VARCHAR(12) NOT NULL DEFAULT 'pending',
-      PRIMARY KEY (id)
+      PRIMARY KEY (id),
+      KEY citizenid (citizenid),
+      KEY ready_at (ready_at),
+      KEY status (status)
     )
   ]], {})
 end


### PR DESCRIPTION
## Summary
- index work order table by citizen, ready time, and status
- ensure schema and resume pending orders on startup

## Testing
- `luac -p respawn/server-data/resources/[respawn]/respawn_workshops/server.lua && echo 'luac ok'`

------
https://chatgpt.com/codex/tasks/task_e_68a092fbc424832893dfe26de17d8c3e