### PR TITLE
Return structured no-cash error for RequestClaim

### DIFF
--- a/respawn/server-data/resources/[respawn]/respawn_weapons/server.lua
+++ b/respawn/server-data/resources/[respawn]/respawn_weapons/server.lua
@@ -100,7 +100,8 @@ RegisterNetEvent('respawn:weapons:claim', function(family, branch, level)
   end
 
   if not ok then
-    TriggerClientEvent('QBCore:Notify', src, 'No se pudo iniciar el trabajo: '..(info or 'error'), 'error')
+    local msg = (type(info) == 'table' and info.msg) or (info or 'error')
+    TriggerClientEvent('QBCore:Notify', src, 'No se pudo iniciar el trabajo: '..msg, 'error')
   else
     local wait = (info and info.wait) or 0
     TriggerClientEvent('QBCore:Notify', src, ('Encargo iniciado: listo en %ds'):format(wait), 'primary')

--- a/respawn/server-data/resources/[respawn]/respawn_workshops/server.lua
+++ b/respawn/server-data/resources/[respawn]/respawn_workshops/server.lua
@@ -10,11 +10,15 @@ local function humanError(code)
     ['no-player'] = 'Jugador no encontrado.',
     ['not-eligible'] = 'No eres elegible todavía.',
     ['loyalty'] = 'Bloqueado por lealtad tras cambio de bando.',
-    ['no-cash'] = 'Fondos insuficientes.',
+    ['no-cash'] = 'Fondos insuficientes',
     ['need-knife'] = 'Primero reclama el Cuchillo.',
     ['locked-by-progression'] = 'Aún no puedes reclamar esta familia (progresión bloqueada).',
     ['need-level0'] = 'Primero reclama el nivel 0 de esta familia.'
   }
+  if type(code) == 'table' then
+    if code.msg then return code.msg end
+    code = code.code
+  end
   -- no-item:name|need:N|have:H
   if type(code) == 'string' and code:sub(1,7) == 'no-item' then
     local name, need, have = code:match('no%-item:(.-)|need:(%d+)|have:(%d+)')
@@ -180,7 +184,9 @@ exports('RequestClaim', function(src, family, branch, level)
   local costCash = prev.costCash or 0
   local mats = prev.materials or {}
 
-  if Player.Functions.GetMoney('cash') < costCash then return false, 'no-cash' end
+  if Player.Functions.GetMoney('cash') < costCash then
+    return false, {code='no-cash', msg='Fondos insuficientes'}
+  end
   local ok, name, need, have = hasMaterials(src, mats)
   if not ok then return false, ('no-item:%s|need:%d|have:%d'):format(name,need,have) end
 


### PR DESCRIPTION
## Summary
- Allow humanError to accept {code,msg} tables
- RequestClaim returns `{code='no-cash', msg='Fondos insuficientes'}` when cash is insufficient
- Adjust weapon claim notifications to use table messages

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/RespawnServer/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a092ff30e083289c6dca8649bc1a6c