### PR TITLE
Persist respawn HUD state

### DIFF
--- a/respawn/server-data/resources/[respawn]/respawn_hud/client.lua
+++ b/respawn/server-data/resources/[respawn]/respawn_hud/client.lua
@@ -1,4 +1,5 @@
-local enabled = HUD.enabledByDefault
+local stored = GetResourceKvpString('respawn_hud_enabled')
+local enabled = stored == nil and HUD.enabledByDefault or GetResourceKvpInt('respawn_hud_enabled') == 1
 local state = {
   heat = 0, civis = 0, active = 'neutral',
   eligible = { heat = 0, civis = 0 },
@@ -51,6 +52,7 @@ end)
 RegisterCommand('respawn_hud', function()
   enabled = not enabled
   if enabled and state.rep == 0 then state.rep = computeRep() end
+  SetResourceKvpInt('respawn_hud_enabled', enabled and 1 or 0)
   if GetResourceState('ox_lib') == 'started' then
     lib.notify({ title='Respawn HUD', description=(enabled and 'Activado' or 'Ocultado'), type=(enabled and 'success' or 'warning') })
   end
@@ -122,7 +124,7 @@ CreateThread(function()
         drawText(anchorRight and (bx + 0.052) or (bx + 0.004), by - 0.006, 0.30, tag, c, anchorRight)
       end
 
-      Wait(0)
+      Wait(1)
     else
       Wait(500)
     end


### PR DESCRIPTION
## Summary
- remember HUD visibility using resource KVP
- lower draw loop CPU usage with a small wait

## Testing
- `luac -p respawn/server-data/resources/[respawn]/respawn_hud/client.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a095455fb88328b39e0e3aedc7a87b