### PR TITLE
Optimize work order index usage

### DIFF
--- a/respawn/server-data/resources/[respawn]/respawn_workshops/server.lua
+++ b/respawn/server-data/resources/[respawn]/respawn_workshops/server.lua
@@ -39,9 +39,14 @@ local function ensureSchema()
       status VARCHAR(12) NOT NULL DEFAULT 'pending',
       PRIMARY KEY (id),
       KEY citizenid (citizenid),
-      KEY ready_at (ready_at),
-      KEY status (status)
+      KEY status_ready_at (status, ready_at)
     )
+  ]], {})
+
+  ox:executeSync([[ALTER TABLE respawn_work_orders
+    DROP INDEX IF EXISTS ready_at,
+    DROP INDEX IF EXISTS status,
+    ADD INDEX IF NOT EXISTS status_ready_at (status, ready_at)
   ]], {})
 end
 


### PR DESCRIPTION
## Summary
- add composite `(status, ready_at)` index to `respawn_work_orders`
- drop outdated standalone indexes

## Testing
- `luac -p respawn/server-data/resources/[respawn]/respawn_workshops/server.lua`
- `mysql --socket=/tmp/mysql.sock -uroot QBCore_A0764D -e "EXPLAIN SELECT level FROM respawn_weapons_blueprints WHERE citizenid='c1' AND family='fam' AND branch='heat'"`
- `mysql --socket=/tmp/mysql.sock -uroot QBCore_A0764D -e "EXPLAIN SELECT * FROM respawn_work_orders WHERE status='pending' AND ready_at < 200"`


------
https://chatgpt.com/codex/tasks/task_e_68a09aa27b48832882cf5a883a22d566