### PR TITLE
Force respawn UI visibility with inline styles

### DIFF
--- a/respawn/server-data/resources/[respawn]/respawn_ui/web/app.js
+++ b/respawn/server-data/resources/[respawn]/respawn_ui/web/app.js
@@ -147,6 +147,7 @@ function renderAll() {
   renderColumn('civis');
 
   els.app.classList.remove('hidden');
+  els.app.style.display = 'block';
   // HUD mock (solo para pintar algo)
   els.hudHeat.style.width = '35%';
   els.hudCivis.style.width = '55%';
@@ -179,11 +180,16 @@ async function openModal(branch, entry) {
   els.btnCancel.onclick = closeModal;
 
   els.modal.classList.remove('hidden');
+  els.modal.style.display = 'flex';
 }
-function closeModal(){ els.modal.classList.add('hidden'); }
+function closeModal(){
+  els.modal.classList.add('hidden');
+  els.modal.style.display = 'none';
+}
 
 function closeUI(){
   els.app.classList.add('hidden');
+  els.app.style.display = 'none';
   Nui.post('close', {});
 }
 


### PR DESCRIPTION
## Summary
- Ensure respawn UI panel explicitly sets `display: block` when shown
- Force modal and UI close actions to hide via `display: none`

## Testing
- `node --check respawn/server-data/resources/[respawn]/respawn_ui/web/app.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a812de3c8328bf5c4c501bba980d