### PR TITLE
Add inline fallback to hide UI without CSS

### DIFF
--- a/respawn/server-data/resources/[respawn]/respawn_ui/web/index.html
+++ b/respawn/server-data/resources/[respawn]/respawn_ui/web/index.html
@@ -5,6 +5,9 @@
   <title>Respawn — Weapons Panel</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link href="app.css" rel="stylesheet" />
+  <style>
+    .hidden { display: none; }
+  </style>
 </head>
 <body>
   <div id="app" class="hidden">


### PR DESCRIPTION
## Summary
- ensure weapon panel UI elements remain hidden by default even if `app.css` fails to load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a80d28cc8328ba40c74a12f216f4