### PR TITLE
chore: fix respawn manifests and load order

### DIFF
--- a/respawn/server-data/resources/[respawn]/respawn_alignment/fxmanifest.lua
+++ b/respawn/server-data/resources/[respawn]/respawn_alignment/fxmanifest.lua
@@ -6,14 +6,6 @@ name 'respawn_alignment'
 description 'Respawn - HEAT/CIVIS alignment core'
 version '0.3.1'
 
-shared_scripts {
-  'config.lua'
-}
-
-client_scripts {
-  'client.lua'
-}
-
 server_scripts {
   'server/alignment.lua'
 }
@@ -22,3 +14,4 @@ dependencies {
   'qb-core',
   'oxmysql'
 }
+

--- a/respawn/server-data/resources/[respawn]/respawn_ui/fxmanifest.lua
+++ b/respawn/server-data/resources/[respawn]/respawn_ui/fxmanifest.lua
@@ -1,22 +1,25 @@
 fx_version 'cerulean'
 game 'gta5'
+lua54 'yes'
 
 name 'respawn_ui'
-description 'Respawn - NUI: weapons panel (HEAT/CIVIS) + HUD (mock)'
-version '0.2.0'
-lua54 'yes'
+description 'Respawn — Panel HEAT/CIVIS (NUI)'
+version '1.0.0'
 
 ui_page 'web/index.html'
 
 files {
   'web/index.html',
-  'web/app.css',
   'web/app.js',
-  'web/locales/es-ES.json',
-  'web/locales/en-EN.json',
-  'web/data/alignment.config.json'
+  'web/app.css',
+  'web/locales/*.json'
 }
 
 client_scripts {
   'client.lua'
 }
+
+dependencies {
+  'qb-core'
+}
+

--- a/respawn/server-data/resources/[respawn]/respawn_workshops/fxmanifest.lua
+++ b/respawn/server-data/resources/[respawn]/respawn_workshops/fxmanifest.lua
@@ -4,29 +4,25 @@ lua54 'yes'
 
 name 'respawn_workshops'
 description 'Respawn - talleres CIVIS/HEAT, costes, tiempos y cola de trabajo'
-version '0.2.1' -- bump menor por corrección de manifest
+version '0.2.1'
 
--- ox_lib primero si lo usas (lib.*)
 shared_scripts {
-  '@ox_lib/init.lua',
+  '@ox_lib/init.lua', -- keep only if ox_lib is actually used
   'config.lua'
 }
 
--- Un solo bloque de server_scripts: añade aquí TODOS los server-side que existan
 server_scripts {
-  'server.lua',            -- quítalo si no existe en tu recurso
   'server/workshop.lua'
 }
 
--- Client opcional; mantenlo solo si realmente tienes client-side
 client_scripts {
-  'client.lua'             -- quítalo si no existe
+  'client.lua' -- remove if not present
 }
 
--- Asegura orden y presencia de dependencias reales
 dependencies {
   'qb-core',
   'oxmysql',
   'ox_lib',
-  'respawn_alignment'      -- para que el taller arranque después del alignment
+  'respawn_alignment'
 }
+

--- a/respawn/server-data/server.cfg
+++ b/respawn/server-data/server.cfg
@@ -46,6 +46,7 @@ setr UseTarget false
 # --- Núcleo base ---
 ensure oxmysql
 ensure qb-core
+ensure ox_lib
 
 # QBCore básicos (mínimo viable)
 ensure qb-multicharacter
@@ -56,11 +57,7 @@ ensure qb-weapons
 # ... (el resto de [qb] como ya tengas)
 
 # --- Respawn (tus recursos) ---
-ensure [respawn]              # si has creado el grupo [respawn]
-# o bien:
 
-ensure respawn_weapons
-ensure respawn_hud
 ensure respawn_alignment
 ensure respawn_workshops
 ensure respawn_ui


### PR DESCRIPTION
## Summary
- simplify respawn_alignment manifest to server-only
- tidy respawn_workshops manifest and dependencies
- update respawn_ui manifest and ensure resources load in proper order

## Testing
- `luac -p respawn/server-data/resources/[respawn]/respawn_alignment/fxmanifest.lua`
- `luac -p respawn/server-data/resources/[respawn]/respawn_workshops/fxmanifest.lua`
- `luac -p respawn/server-data/resources/[respawn]/respawn_ui/fxmanifest.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a0b25a9f9c8328a9ae27e130e7d200